### PR TITLE
fixed some relics and replaced 1 - p by p

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -9,8 +9,8 @@ import unittest
 test_layer = tk.TopKastLinear(
     in_features=100, 
     out_features=1, 
-    topk_forward=40,
-    topk_backward=50,
+    p_forward=0.6,
+    p_backward=0.4,
     bias=True)
 
 #%% Unit test: class
@@ -25,21 +25,21 @@ class TestClass(unittest.TestCase):
 
 class TestArgs(unittest.TestCase):
     def test_count_infeatures(self):
-        self.assertRaises(AssertionError, tk.TopKastLinear, 100.5, 1, 40, 50)
-        self.assertRaises(AssertionError, tk.TopKastLinear, -100, 1, 40, 50)
+        self.assertRaises(AssertionError, tk.TopKastLinear, 100.5, 1, 0.6, 0.4)
+        self.assertRaises(AssertionError, tk.TopKastLinear, -100, 1, 0.6, 0.4)
     def test_count_outfeatures(self):
-        self.assertRaises(AssertionError, tk.TopKastLinear, 100, 1.5, 40, 50)
-        self.assertRaises(AssertionError, tk.TopKastLinear, 100, 0, 40, 50)
+        self.assertRaises(AssertionError, tk.TopKastLinear, 100, 1.5, 0.6, 0.4)
+        self.assertRaises(AssertionError, tk.TopKastLinear, 100, 0, 0.6, 0.4)
     def test_count_topkforward(self):
-        self.assertRaises(AssertionError, tk.TopKastLinear, 100, 1.5, 40.5, 50)
-        self.assertRaises(AssertionError, tk.TopKastLinear, 100, 1.5, -40, 50)
+        self.assertRaises(AssertionError, tk.TopKastLinear, 100, 1.5, 1.6, 0.4)
+        self.assertRaises(AssertionError, tk.TopKastLinear, 100, 1.5, -0.6, 0.4)
     def test_count_topkbackward(self):
-        self.assertRaises(AssertionError, tk.TopKastLinear, 100, 1.5, 40, 50.5)
-        self.assertRaises(AssertionError, tk.TopKastLinear, 100, 1.5, 40, -50)
-    def test_topkbackward_geq_topkforward(self):
-        self.assertRaises(AssertionError, tk.TopKastLinear, 100, 1, 40, 30)
+        self.assertRaises(AssertionError, tk.TopKastLinear, 100, 1.5, 0.6, 1.4)
+        self.assertRaises(AssertionError, tk.TopKastLinear, 100, 1.5, 0.6, -0.4)
+    def test_fwsparsity_geq_bwsparsity(self):
+        self.assertRaises(AssertionError, tk.TopKastLinear, 100, 1, 0.6, 0.8)
     def test_bool_bias(self):
-        self.assertRaises(AssertionError, tk.TopKastLinear, 100, 1, 40, 50, 1)
+        self.assertRaises(AssertionError, tk.TopKastLinear, 100, 1, 0.6, 0.4, 1)
     
 #%% Unit test: bias & weights
 
@@ -57,17 +57,13 @@ class TestWeightsBias(unittest.TestCase):
 
 class TestSparsity(unittest.TestCase):
     def test_has_right_forward_sparsity(self):
-        vals = test_layer.sparse_weights().coalesce().values()
-        self.assertAlmostEqual(
-            test_layer.in_features - vals.numel(),
-            # TODO align with final def of topk_*ward
-            test_layer.topk_forward)
+        d = test_layer.weight.numel()
+        s = test_layer.sparse_weights().coalesce().values().numel()
+        self.assertAlmostEqual(s, (1 - test_layer.p_forward) * d)
     def test_has_right_backward_sparsity(self):
-        vals = test_layer.sparse_weights(forward=False).coalesce().values()
-        self.assertAlmostEqual(
-            test_layer.in_features - vals.numel(),
-            # TODO align with final def of topk_*ward
-            test_layer.topk_backward)    
+        d = test_layer.weight.numel()
+        s = test_layer.sparse_weights(forward=False).coalesce().values().numel()
+        self.assertAlmostEqual(s, (1 - test_layer.p_backward) * d)
     
 #%% Unit test: output
 

--- a/topkast_linear.py
+++ b/topkast_linear.py
@@ -84,10 +84,11 @@ class TopKastLinear(nn.Module):
         for i in [in_features, out_features]:
             assert type(i) == int, 'integer input required'
             assert i > 0, 'inputs must be > 0'
-        for i in [topk_forward, topk_backward]:
+        for i in [p_forward, p_backward]:
             assert type(i) == float, 'float input required'
-            assert i > 0 & i <= 1, 'inputs must be a percentage between 0 and 1'
-        assert p_forward >= p_backward
+            assert i > 0, 'inputs must be between 0 and 1'
+            assert i <= 1, 'inputs must be between 0 and 1'
+        assert p_forward > p_backward
         assert type(bias) == bool
             
         # Initialize
@@ -103,7 +104,7 @@ class TopKastLinear(nn.Module):
         else:
             self.register_parameter('bias', None)
         self.reset_parameters()
-        self.D = self.topk_forward / (self.weight.shape.numel())
+        # self.D = self.topk_forward / (self.weight.shape.numel())
         
     # Define weight initialization (He et al., 2015)
 
@@ -122,10 +123,10 @@ class TopKastLinear(nn.Module):
     def compute_mask(self, p):
         w = self.weight
         if w.is_sparse:
-            threshold = torch.quantile(w.values().detach().abs(), 1 - p)
+            threshold = torch.quantile(w.values().detach().abs(), p)
             mask = np.where(w.values().detach().abs() >= threshold)
         else:
-            threshold = torch.quantile(w.reshape(-1).detach().abs(), 1 - p)
+            threshold = torch.quantile(w.reshape(-1).detach().abs(), p)
             mask = np.where(w.detach().abs() >= threshold)
         return mask
     


### PR DESCRIPTION
muss imho jetzt schon p heißen (siehe auch unit test :))
rechenbeispiel:
* verlange forward sparsity von 80 %, also p_forward = 0.8
* mit 1 - p: berechne 0.2-quantil und nehme werte drüber --> top 80 % sind dense, 20 % sparsity ~FALSCH~
* mit p: berechne 0.8-quantil und nehme werte drüber --> top 20 % sind dense, 80 % sparsity RICHTIG
